### PR TITLE
Revert "Use the port regex"

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,8 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			tooltip: 'Default Port 8080 - Do Not Change',
 			width: 4,
 			default: 8080,
-			regex: Regex.PORT,
+			min: 1,
+			max: 65535,
 		},
 	]
 }


### PR DESCRIPTION
Reverts bitfocus/companion-module-phabrix-qx#2

As per https://github.com/bitfocus/companion-module-base/issues/129 it doesn't currently work in TS but does in JS. Sorry for the noise...